### PR TITLE
Fix Postgres Docker flake and update 14.4 -> 14.6

### DIFF
--- a/example/golden/raw_dump.sql
+++ b/example/golden/raw_dump.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 14.4 (Debian 14.4-1.pgdg110+1)
--- Dumped by pg_dump version 14.4 (Debian 14.4-1.pgdg110+1)
+-- Dumped from database version 14.6 (Debian 14.6-1.pgdg110+1)
+-- Dumped by pg_dump version 14.6 (Debian 14.6-1.pgdg110+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;


### PR DESCRIPTION
This PR fixes an issue with our Docker Postgres connection where we sometimes connect before Postgres is fully up, see [1] for more details.

[1] https://github.com/docker-library/postgres/issues/146
