### PR TITLE
Use a *pgxpool.Pool instead of a *pgx.Conn

### DIFF
--- a/example/main_test.go
+++ b/example/main_test.go
@@ -56,7 +56,7 @@ func runTests(m *testing.M) int {
 func TestDumpSchema(t *testing.T) {
 	ctx := context.Background()
 	db := env.GetMigratedDB(ctx, t)
-	sqlDump, err := env.DumpDatabaseSchema(ctx, db.Config().Config.Database)
+	sqlDump, err := env.DumpDatabaseSchema(ctx, db.Config().ConnConfig.Database)
 	if err != nil {
 		t.Fatalf("failed to dump database schema: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestDumpSchema(t *testing.T) {
 func TestDumpHumanReadableSchema(t *testing.T) {
 	ctx := context.Background()
 	db := env.GetMigratedDB(ctx, t)
-	sqlDump, err := env.DumpDatabaseSchema(ctx, db.Config().Config.Database, testpgx.WithHumanReadableSchema())
+	sqlDump, err := env.DumpDatabaseSchema(ctx, db.Config().ConnConfig.Database, testpgx.WithHumanReadableSchema())
 	if err != nil {
 		t.Fatalf("failed to dump database schema: %v", err)
 	}


### PR DESCRIPTION
The motivation for this is tests that are testing explicitly for concurrency, or require multiple queries in parallel. Using a single conn in such cases will cause problems, as conns are not concurrency-safe.

pgxpool.Pool is concurrency-safe though, so we use that with a sensible number of max conns.

In the future, we might want to make this configurable.
