### PR TITLE
Show error on failure to start, and create socket subdir

### DIFF
--- a/testpgx.go
+++ b/testpgx.go
@@ -156,6 +156,9 @@ func New(ctx context.Context, opts ...Option) (*Env, error) {
 	if err := os.Chmod(tmpDir, 0766); err != nil {
 		return nil, fmt.Errorf("failed to change permissions on socket temp dir: %w", err)
 	}
+	if err := os.Mkdir(socketDir, 0766); err != nil {
+		return nil, fmt.Errorf("failed to create socket sub-dir: %w", err)
+	}
 
 	if err := exec.CommandContext(ctx, o.dockerBinaryPath, "pull", o.postgresDockerImage).Run(); err != nil {
 		return nil, fmt.Errorf("failed to pull postgres docker image %q: %w", o.postgresDockerImage, err)
@@ -173,7 +176,7 @@ func New(ctx context.Context, opts ...Option) (*Env, error) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("while starting postgres: %w", err)
+		return nil, fmt.Errorf("while starting postgres %q: %w", string(out), err)
 	}
 
 	cID, err := getPostgresContainerID(out)


### PR DESCRIPTION
Showing the error encountered by docker (or podman) helps debug things. Also creates the socket subdir, which is needed when using rootless podman.
